### PR TITLE
Clean up timer display CSS

### DIFF
--- a/app.py
+++ b/app.py
@@ -351,11 +351,6 @@ st.markdown(f"""
         font-family: 'Courier New', monospace;
         line-height: 0.85;
         letter-spacing: 0.03em;
-    }};
-        text-align: center;
-        margin: 1rem 0;
-        font-family: 'Courier New', monospace;
-        line-height: 0.9;
     }}
 
     .timer-display.overtime {{


### PR DESCRIPTION
## Summary
- remove stray semicolon and duplicated CSS declarations in `.timer-display`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `streamlit run app.py` (checked with `curl -I http://localhost:8501`)


------
https://chatgpt.com/codex/tasks/task_e_68ab85bec9ac8331979a8a9a50b26ea3