### PR TITLE
Normalize time and duration inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import pytz
 import json
 import os
 import re
+import unicodedata
 
 # ページ設定
 st.set_page_config(
@@ -26,8 +27,9 @@ def parse_time_input(time_str):
     if not time_str:
         return None
 
-    # 文字列から数字とコロンのみを抽出
-    clean_str = re.sub(r'[^\d:]', '', str(time_str))
+    # 全角などを正規化してから数字とコロンのみを抽出
+    time_str = unicodedata.normalize('NFKC', str(time_str))
+    clean_str = re.sub(r'[^\d:]', '', time_str)
 
     try:
         # コロンが含まれている場合
@@ -78,8 +80,9 @@ def parse_duration_input(duration_str):
     if not duration_str:
         return None
 
-    # 文字列から数字とコロンのみを抽出
-    clean_str = re.sub(r'[^\d:]', '', str(duration_str))
+    # 全角などを正規化してから数字とコロンのみを抽出
+    duration_str = unicodedata.normalize('NFKC', str(duration_str))
+    clean_str = re.sub(r'[^\d:]', '', duration_str)
 
     try:
         # コロンが含まれている場合（分:秒）


### PR DESCRIPTION
## Summary
- normalize Unicode input with NFKC before time and duration parsing
- add unicodedata import

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import logging
for name in ['streamlit', 'streamlit.runtime', 'streamlit.runtime.scriptrunner_utils', 'streamlit.runtime.state', 'streamlit.runtime.state.session_state_proxy']:
    logging.getLogger(name).setLevel(logging.ERROR)
import app
print(app.parse_time_input('７：３０'))
print(app.parse_duration_input('１５：００'))
print(app.parse_time_input('12:34'))
print(app.parse_duration_input('15'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ab85b7cafc8331913e4f8ea6ceb373