### PR TITLE
改善: プレゼンモード時間切れ時の文字色

### DIFF
--- a/app.py
+++ b/app.py
@@ -357,7 +357,7 @@ st.markdown(f"""
     }}
 
     .timer-display.overtime {{
-        color: #ff4444 !important;
+        color: #ffffff !important;
         animation: pulse 1s infinite;
     }}
 


### PR DESCRIPTION
## Summary
- プレゼンテーションモードでカウントダウン終了後のタイマー文字色を白に変更し、背景とのコントラストを向上

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac416e6fb08331ae7900a6478079ee