### PR TITLE
Use pink for countdown progress bar

### DIFF
--- a/app.py
+++ b/app.py
@@ -355,6 +355,10 @@ st.markdown(f"""
         line-height: 1;
     }}
 
+    div.stProgress > div > div > div > div {{
+        background-color: #c5487b;
+    }}
+
     .timer-display {{
         /* カウントダウンを主役に：大きく＆レスポンシブ */
         font-size: clamp(6rem, 22vw, 20rem);


### PR DESCRIPTION
## Summary
- set countdown progress bar to the same pink as the background
- restore countdown text to follow the theme's text color

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac46d022a88331ab9c952b13860126